### PR TITLE
fix: :sparkles: Update Python analysis paths and fix documentation issues

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -76,5 +76,5 @@ jobs:
             fi
         - name: Deploy documentation develops
           run: |
-            poetry run mike deploy --push --rebase --update-aliases ${{ github.event.release.tag_name }} latest --message "Release ${{ github.event.release.tag_name }}"
-            poetry run mike set-default --push --rebase latest
+            poetry run mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest --message "Release ${{ github.event.release.tag_name }}"
+            poetry run mike set-default --push latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
   "python.defaultInterpreterPath": "python",
   "python.analysis.importFormat": "absolute",
   "python.analysis.enablePytestExtra": true,
-  "python.analysis.enableSyncServer": true
+  "python.analysis.enableSyncServer": true,
+  "python.analysis.extraPaths": [
+    "umf"
+  ]
 }

--- a/docs/modules/functions/theory/pathological.md
+++ b/docs/modules/functions/theory/pathological.md
@@ -1,7 +1,7 @@
 ## Weierstrass Function
 
 <!-- prettier-ignore -->
-::: umf.functions.optimization.theory.WeierstrassFunction
+::: umf.functions.theory.pathological.WeierstrassFunction
     options:
         show_bases: false
         show_source: true
@@ -18,7 +18,7 @@
 ## Riemann Function
 
 <!-- prettier-ignore -->
-::: umf.functions.optimization.theory.RiemannFunction
+::: umf.functions.theory.pathological.RiemannFunction
     options:
         show_bases: false
         show_source: true
@@ -34,7 +34,7 @@
 ## Takagi Function
 
 <!-- prettier-ignore -->
-::: umf.functions.optimization.theory.TakagiFunction
+::: umf.functions.theory.pathological.TakagiFunction
     options:
         show_bases: false
         show_source: true
@@ -51,7 +51,7 @@
 ## Mandelbrot's Fractal Function
 
 <!-- prettier-ignore -->
-::: umf.functions.optimization.theory.MandelbrotsFractalFunction
+::: umf.functions.theory.pathological.MandelbrotsFractalFunction
     options:
         show_bases: false
         show_source: true
@@ -68,7 +68,7 @@
 ## Besicovitch Function
 
 <!-- prettier-ignore -->
-::: umf.functions.optimization.theory.BesicovitchFunction
+::: umf.functions.theory.pathological.BesicovitchFunction
     options:
         show_bases: false
         show_source: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -238,7 +238,7 @@ nav:
               - Modules: modules/api/optimization.md
           - Theory:
               - Modules: modules/api/theory.md
-        - Others:
+      - Others:
           - Data Generation:
               - Modules: modules/api/data_generation.md
           - Meta Models & Patterns:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2294,4 +2294,4 @@ plotly = ["kaleido", "plotly"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "e765a636335366130e687bc2741ef15f8633304f263f950f20560e6c5dd21e95"
+content-hash = "b4793da2393d3e7f71dd64e868ad5d37406af306988327ca2fed13aabeb55393"

--- a/poetry.lock
+++ b/poetry.lock
@@ -561,6 +561,40 @@ Pillow = "*"
 requests = "*"
 
 [[package]]
+name = "importlib-metadata"
+version = "8.0.0"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f"},
+    {file = "importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "importlib-resources"
+version = "6.4.0"
+description = "Read resources from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_resources-6.4.0-py3-none-any.whl", hash = "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c"},
+    {file = "importlib_resources-6.4.0.tar.gz", hash = "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -903,24 +937,28 @@ files = [
 
 [[package]]
 name = "mike"
-version = "1.1.2"
+version = "2.1.2"
 description = "Manage multiple versions of your MkDocs-powered documentation"
 optional = false
 python-versions = "*"
 files = [
-    {file = "mike-1.1.2-py3-none-any.whl", hash = "sha256:4c307c28769834d78df10f834f57f810f04ca27d248f80a75f49c6fa2d1527ca"},
-    {file = "mike-1.1.2.tar.gz", hash = "sha256:56c3f1794c2d0b5fdccfa9b9487beb013ca813de2e3ad0744724e9d34d40b77b"},
+    {file = "mike-2.1.2-py3-none-any.whl", hash = "sha256:d61d9b423ab412d634ca2bd520136d5114e3cc73f4bbd1aa6a0c6625c04918c0"},
+    {file = "mike-2.1.2.tar.gz", hash = "sha256:d59cc8054c50f9c8a046cfd47f9b700cf9ff1b2b19f420bd8812ca6f94fa8bd3"},
 ]
 
 [package.dependencies]
-jinja2 = "*"
+importlib-metadata = "*"
+importlib-resources = "*"
+jinja2 = ">=2.7"
 mkdocs = ">=1.0"
+pyparsing = ">=3.0"
 pyyaml = ">=5.1"
+pyyaml-env-tag = "*"
 verspec = "*"
 
 [package.extras]
-dev = ["coverage", "flake8 (>=3.0)", "shtab"]
-test = ["coverage", "flake8 (>=3.0)", "shtab"]
+dev = ["coverage", "flake8 (>=3.0)", "flake8-quotes", "shtab"]
+test = ["coverage", "flake8 (>=3.0)", "flake8-quotes", "shtab"]
 
 [[package]]
 name = "mkdocs"
@@ -1692,7 +1730,7 @@ extra = ["pygments (>=2.12)"]
 name = "pyparsing"
 version = "3.1.2"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-optional = true
+optional = false
 python-versions = ">=3.6.8"
 files = [
     {file = "pyparsing-3.1.2-py3-none-any.whl", hash = "sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742"},
@@ -2233,6 +2271,21 @@ files = [
 [package.extras]
 dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 
+[[package]]
+name = "zipp"
+version = "3.19.2"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
+    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
+]
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
 [extras]
 all = ["imagemagic", "kaleido", "matplotlib", "plotly"]
 matplotlib = ["imagemagic", "matplotlib"]
@@ -2241,4 +2294,4 @@ plotly = ["kaleido", "plotly"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "f3fa0622bb443ecb3f39873cf1ee2cea27ddcd1a7f630c43fdfd6ca6b1669175"
+content-hash = "e765a636335366130e687bc2741ef15f8633304f263f950f20560e6c5dd21e95"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ mkdocs-section-index = "^0.3.5"
 mike = "^2.1.2"
 mkdocs-table-reader-plugin = "^2.0.1"
 pymdown-extensions = "^10.1"
-mkdocs-material-extensions = "^1.1.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ mkdocstrings = { extras = ["python"], version = "^0.22.0" }
 mathjax = "^0.1.2"
 mkdocs-literate-nav = "^0.6.0"
 mkdocs-section-index = "^0.3.5"
-mike = "^1.1.2"
+mike = "^2.1.2"
 mkdocs-table-reader-plugin = "^2.0.1"
 pymdown-extensions = "^10.1"
 mkdocs-material-extensions = "^1.1.1"

--- a/umf/functions/theory/pathological.py
+++ b/umf/functions/theory/pathological.py
@@ -30,7 +30,7 @@ class WeierstrassFunction(PathologicalWithCoefficients):
     continuous everywhere but differentiable nowhere. It is defined by an infinite
     series that oscillates too wildly to settle down to a smooth curve.
 
-    Example:
+    Examples:
         >>> import matplotlib.pyplot as plt
         >>> from matplotlib.animation import FuncAnimation
         >>> import numpy as np
@@ -117,7 +117,7 @@ class RiemannFunction(PathologicalPure):
     a series of terms. Each term in the series is calculated using the
     Riemann zeta function and the sine function.
 
-    Example:
+    Examples:
         >>> import matplotlib.pyplot as plt
         >>> from matplotlib.animation import FuncAnimation
         >>> import numpy as np
@@ -177,7 +177,7 @@ class TakagiFunction(PathologicalPure):
     The Takagi function is a fractal-like continuous function defined on the real line.
     It is also known as the Takagi-Landsberg function or the Blancmange function.
 
-    Example:
+    Examples:
         >>> import matplotlib.pyplot as plt
         >>> from matplotlib.animation import FuncAnimation
         >>> import numpy as np
@@ -252,7 +252,7 @@ class MandelbrotsFractalFunction(PathologicalPure):
     complex and boundary-defining structure, which reveals an infinitely detailed and
     varied pattern upon magnification.
 
-    Example:
+    Examples:
         >>> import matplotlib.pyplot as plt
         >>> from matplotlib.animation import FuncAnimation
         >>> import numpy as np
@@ -339,7 +339,7 @@ class BesicovitchFunction(PathologicalPure):
     The Besicovitch function is a fractal-like continuous function defined on the
     real line. It is also known as the Besicovitch-Eggleston function.
 
-    Example:
+    Examples:
         >>> import matplotlib.pyplot as plt
         >>> from matplotlib.animation import FuncAnimation
         >>> import numpy as np


### PR DESCRIPTION
This pull request includes several updates and fixes to the codebase and documentation.

The commits in this pull request address the following changes:

- Update `.vscode/settings.json` to include additional Python analysis paths.

- Fix an indentation issue in `mkdocs.yml`.

- Update the `mike` package from version `v1` to `v2`.

- Update `poetry.lock` and `pyproject.toml` files.

- Update the `mike` deploy command in the `python-publish` workflow to remove the `--rebase` flag and update the `latest` alias without rebasing. This ensures proper deployment of documentation for each release.

- Update the paths in the theory functions module in the documentation.

- Correct labeling for the example section in the documentation.
