### PR TITLE
chore: change backend for emoji generation

### DIFF
--- a/docs/modules/functions/optimization/special.md
+++ b/docs/modules/functions/optimization/special.md
@@ -83,8 +83,8 @@
         heading_level: 0
         members: None
 
-|                                                                 |
-| :-------------------------------------------------------------: |
+|                                                                     |
+| :-----------------------------------------------------------------: |
 | ![HimmelblauFunction](../../../extra/images/HimmelblauFunction.png) |
 
 ## Styblinski-Tang Function

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,8 +120,8 @@ markdown_extensions:
   - pymdownx.critic:
   - pymdownx.details:
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.escapeall:
       hardbreak: True
       nbsp: True


### PR DESCRIPTION
This pull request includes a small change to the `mkdocs.yml` file. The change updates the `emoji_index` and `emoji_generator` settings to use the correct module paths for the `material.extensions.emoji` module instead of the deprecated `materialx.emoji` module.

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L123-R124): Updated `emoji_index` and `emoji_generator` settings to use `material.extensions.emoji` module.